### PR TITLE
feat: adiciona função filtrar_pares para filtrar números pares

### DIFF
--- a/manipulador_lista.php
+++ b/manipulador_lista.php
@@ -10,6 +10,14 @@ function ordenar_crescente($lista)
     return $copia;
 }
 
+//Função filtrar pares
+function filtrar_pares($lista) {
+    return array_filter($lista, function($num) {
+        return $num % 2 === 0;
+    });
+}
+
+
 
 /**
  * Função principal que executa uma estratégia específica sobre a lista
@@ -28,5 +36,9 @@ echo "Lista original: " . implode(", ", $numeros) . "\n";
 // Aplicando ordenação crescente
 $resultado = ordenar_crescente($numeros);
 echo "Lista ordenada: " . implode(", ", $resultado) . "\n";
+
+//Filtra pares
+$resultado = executar_estrategia($lista, 'filtrar_pares');
+print_r($resultado);
 
 ?>


### PR DESCRIPTION
Esta PR adiciona a função `filtrar_pares` que filtra todos os números pares de uma lista.
A função foi implementada e integrada à função `executar_estrategia`.

Exemplo de uso:
$resultado = executar_estrategia($numeros, 'filtrar_pares');

Lista original: [1, 2, 3, 4] → Resultado: [2, 4]